### PR TITLE
correccion sintaxis

### DIFF
--- a/app/src/features/APIs/components/APIDialog.jsx
+++ b/app/src/features/APIs/components/APIDialog.jsx
@@ -64,7 +64,7 @@ export function APIDialog({ open, handleClose, handleSubmit }) {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose}>Cancelaar</Button>
+          <Button onClick={handleClose}>Cancelar</Button>
           <Button type="submit"> Guardar </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
Corregí el mensaje cancelar mal escrito en el Diaglog de APIs